### PR TITLE
Switch ocp image to use a packaged IPA image

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,9 @@
-FROM rhel7:latest
+FROM ubi8
 
 RUN yum update -y \
  && yum clean all
+
+RUN yum install -y rhosp-director-images-ipa-x86_64
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh
 

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -13,6 +13,22 @@ TMPDIR=$(mktemp -d)
 mkdir -p /shared/html/images
 cd /shared/html/images
 
+# Is this a RHEL based image? If so the IPA image is already here, so
+# we don't need to download it
+if [ -e /usr/share/rhosp-director-images/ironic-python-agent-latest.tar ] ; then
+    VERSION=$(cat /usr/share/rhosp-director-images/version-latest.txt)
+    if [ ! -e $FILENAME-$VERSION ] ; then
+        cd $TMPDIR
+        tar -xf /usr/share/rhosp-director-images/ironic-python-agent-latest.tar
+        chmod 755 $TMPDIR
+        cd -
+        mv $TMPDIR $FILENAME-$VERSION
+    fi
+    ln -sf $FILENAME-$VERSION/$FILENAME.initramfs $FILENAME.initramfs
+    ln -sf $FILENAME-$VERSION/$FILENAME.kernel $FILENAME.kernel
+    exit 0
+fi
+
 # If we have a CACHEURL and nothing has yet been downloaded
 # get header info from the cache
 ls -l


### PR DESCRIPTION
Only download the RDO image if upstream, also switch
to using ubi8 as a base image as OSP is based on RHEL8.