### PR TITLE
Allow curl on cache URL to fail without being fatal

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -17,7 +17,7 @@ cd /shared/html/images
 # get header info from the cache
 ls -l
 if [ -n "$CACHEURL" -a ! -e $FFILENAME.headers ] ; then
-    curl --fail -O "$CACHEURL/$FFILENAME.headers"
+    curl --fail -O "$CACHEURL/$FFILENAME.headers" || true
 fi
 
 # Download the most recent version of IPA


### PR DESCRIPTION
It's ok if the cache doesn't have anything.