### PR TITLE
Stop using /tmp

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -8,10 +8,10 @@ FILENAME=ironic-python-agent
 FILENAME_EXT=.tar
 FFILENAME=$FILENAME$FILENAME_EXT
 
-TMPDIR=$(mktemp -d)
-
-mkdir -p /shared/html/images
+mkdir -p /shared/html/images /shared/tmp
 cd /shared/html/images
+
+TMPDIR=$(mktemp -d -p /shared/tmp)
 
 # Is this a RHEL based image? If so the IPA image is already here, so
 # we don't need to download it


### PR DESCRIPTION
Creating files in /tmp and moving them to the /shared volume
results in them having the wrong selinux context.