### PR TITLE
Install rhosp-director-images-ipa without deps

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,8 +1,11 @@
 FROM ubi8
 
-RUN yum update -y \
- && yum clean all
-
-RUN yum install -y rhosp-director-images-ipa-$(uname -m)
+# We don't need the deps that rhosp-director-images-ipa pulls in
+# use rpm to install without them to keep the image size down as
+# much as possible
+RUN yum install -y rhosp-director-images-ipa-$(uname -m) --downloadonly --downloaddir=/tmp/packages && \
+    rpm -i --nodeps /tmp/packages/rhosp-release-* /tmp/packages/rhosp-director-images-ipa-* && \
+    rm -rf /tmp/packages && \
+    yum clean all
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh


### PR DESCRIPTION
 We don't need the deps that rhosp-director-images-ipa pulls in
 use rpm to install without them to keep the image size down as
 much as possible

