### PR TITLE
Remove unused Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM docker.io/centos:centos7
-
-RUN yum update -y \
- && yum clean all
-
-COPY ./get-resource.sh /usr/local/bin/get-resource.sh
-
-


### PR DESCRIPTION
Dockerfile is not used in Openshift, only Dockerfile.ocp should be
present to avoid confusion.