### PR TITLE
install rhosp-director-images-ipa from url

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,9 +3,10 @@ FROM ubi8
 # We don't need the deps that rhosp-director-images-ipa pulls in
 # use rpm to install without them to keep the image size down as
 # much as possible
-RUN yum install -y rhosp-director-images-ipa-$(uname -m) --downloadonly --downloaddir=/tmp/packages && \
-    rpm -i --nodeps /tmp/packages/rhosp-release-* /tmp/packages/rhosp-director-images-ipa-* && \
-    rm -rf /tmp/packages && \
-    yum clean all
+RUN dnf update -y && \
+    dnf install -y dnf-plugins-core && \
+    rpm -ivh --nodeps $(dnf download --url --urlprotocols=http rhosp-director-images-ipa-$(uname -m) | grep base-4-3-rhel8) && \
+    dnf clean all && \
+    rm -rf /var/cache/{yum,dnf}/*
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh


### PR DESCRIPTION
Install rhosp-director-images-ipa package directly from the repo url to bypass need of dependencies.
This will prevent to tag more packages, since using downloadonly option of yum/dnf still requires to have the dependencies available.
At the moment the package is unfortunately tagged in 2 repos, so we need to grep for the correct one.
