### PR TITLE
Bug 1798385: Use dnf to download the only package we need

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,9 +3,11 @@ FROM ubi8
 # We don't need the deps that rhosp-director-images-ipa pulls in
 # use rpm to install without them to keep the image size down as
 # much as possible
-RUN yum install -y rhosp-director-images-ipa-$(uname -m) --downloadonly --downloaddir=/tmp/packages && \
-    rpm -i --nodeps /tmp/packages/rhosp-release-* /tmp/packages/rhosp-director-images-ipa-* && \
+RUN dnf download rhosp-director-images-ipa-$(uname -m) --destdir /tmp/packages && \
+    rpm -i --nodeps /tmp/packages/rhosp-director-images-ipa-* && \
+    echo $(rpm -q --queryformat '%{VERSION}-%{RELEASE}' /tmp/packages/rhosp-director-images-ipa-$(uname -m)-*.rpm) > /usr/share/rhosp-director-images/version-latest.txt && \
+    mv /usr/share/rhosp-director-images/ironic-python-agent-*.$(uname -m).tar /usr/share/rhosp-director-images/ironic-python-agent-latest.tar && \
     rm -rf /tmp/packages && \
-    yum clean all
+    dnf clean all
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh


### PR DESCRIPTION
Using dnf download should not pull all the dependencies that we
don't really need.