### PR TITLE
Bug1798272 : DHCPv6 set hostname and predictable hostname

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -18,6 +18,14 @@ cd $TMPDIR_RAMDISK
 rpm2cpio /tmp/packages/openstack-ironic-python-agent*.rpm | cpio -ivdum
 rpm2cpio /tmp/packages/python3-ironic-python-agent*.rpm | cpio -ivdum
 rpm2cpio /tmp/packages/python3-ironic-lib*.rpm | cpio -ivdum
+
+# Update netconfig to use MAC for DUID/IAID combo (same as RHCOS)
+# FIXME: we need an alternative of this packaged
+mkdir -p etc/NetworkManager/conf.d etc/NetworkManager/dispatcher.d
+echo -e '[main]\ndhcp=dhclient\n[connection]\nipv6.dhcp-duid=ll' > etc/NetworkManager/conf.d/clientid.conf
+echo -e '[[ "$DHCP6_FQDN_FQDN" =~ - ]] && hostname $DHCP6_FQDN_FQDN' > etc/NetworkManager/dispatcher.d/01-hostname
+chmod +x etc/NetworkManager/dispatcher.d/01-hostname
+
 find . 2>/dev/null | cpio -c -o | gzip -8  > /var/tmp/ironic-python-agent.initramfs
 cp $TMPDIR/ironic-python-agent.kernel /var/tmp/
 cd /var/tmp


### PR DESCRIPTION
We already do this in the RHCOS images, it needs to be
don't here so hostnames and IP addresses match.