### PR TITLE
bug 1804278: set hostnames and make DHCPv6 IDs predictable

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,9 +3,11 @@ FROM ubi8
 # We don't need the deps that rhosp-director-images-ipa pulls in
 # use rpm to install without them to keep the image size down as
 # much as possible
-RUN yum install -y rhosp-director-images-ipa-$(uname -m) --downloadonly --downloaddir=/tmp/packages && \
-    rpm -i --nodeps /tmp/packages/rhosp-release-* /tmp/packages/rhosp-director-images-ipa-* && \
+RUN dnf download rhosp-director-images-ipa-$(uname -m) --destdir /tmp/packages && \
+    rpm -i --nodeps /tmp/packages/rhosp-director-images-ipa-* && \
+    echo $(rpm -q --queryformat '%{VERSION}-%{RELEASE}' /tmp/packages/rhosp-director-images-ipa-$(uname -m)-*.rpm) > /usr/share/rhosp-director-images/version-latest.txt && \
+    mv /usr/share/rhosp-director-images/ironic-python-agent-*.$(uname -m).tar /usr/share/rhosp-director-images/ironic-python-agent-latest.tar && \
     rm -rf /tmp/packages && \
-    yum clean all
+    dnf clean all
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,11 +3,21 @@ FROM ubi8
 # We don't need the deps that rhosp-director-images-ipa pulls in
 # use rpm to install without them to keep the image size down as
 # much as possible
-RUN dnf download rhosp-director-images-ipa-$(uname -m) --destdir /tmp/packages && \
-    rpm -i --nodeps /tmp/packages/rhosp-director-images-ipa-* && \
-    echo $(rpm -q --queryformat '%{VERSION}-%{RELEASE}' /tmp/packages/rhosp-director-images-ipa-$(uname -m)-*.rpm) > /usr/share/rhosp-director-images/version-latest.txt && \
-    mv /usr/share/rhosp-director-images/ironic-python-agent-*.$(uname -m).tar /usr/share/rhosp-director-images/ironic-python-agent-latest.tar && \
+
+COPY ./build-ipa.sh /usr/local/bin/build-ipa.sh
+
+RUN dnf update -y && \
+    dnf install -y cpio dracut && \
+    dnf download --destdir /tmp/packages \
+      rhosp-director-images-ipa-$(uname -m) python3-ironic-lib \
+      python3-ironic-python-agent openstack-ironic-python-agent && \
+    rpm -i --nodeps /tmp/packages/rhosp-director-images-ipa-*.rpm && \
+    chmod +x /usr/local/bin/build-ipa.sh && \
+    /usr/local/bin/build-ipa.sh && \
+    rpm -q --queryformat "%{NAME} %{VERSION} %{RELEASE} %{ARCH}\n" /tmp/packages/*.rpm > /var/tmp/ipa-ramdisk-pkgs.info && \
     rm -rf /tmp/packages && \
-    dnf clean all
+    dnf remove -y rhosp-director-images-ipa-$(uname -m) && \
+    dnf clean all && \
+    rm -rf /var/cache/{yum,dnf}/*
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -3,11 +3,12 @@ set -ex
 
 TMPDIR=$(mktemp -d -p /var/tmp)
 TMPDIR_RAMDISK=$(mktemp -d -p /var/tmp)
-IPA_RAMDISK_VERSION=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}" rhosp-director-images-ipa-x86_64)
+IPA_RAMDISK_ARCH=$(uname -m)
+IPA_RAMDISK_VERSION=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}" rhosp-director-images-ipa-${IPA_RAMDISK_ARCH})
 
 chmod 755 $TMPDIR $TMPDIR_RAMDISK
 cd $TMPDIR
-tar -xf /usr/share/rhosp-director-images/ironic-python-agent-${IPA_RAMDISK_VERSION}.$(uname -m).tar
+tar -xf /usr/share/rhosp-director-images/ironic-python-agent-${IPA_RAMDISK_VERSION}.${IPA_RAMDISK_ARCH}.tar
 cd $TMPDIR_RAMDISK
 /usr/lib/dracut/skipcpio $TMPDIR/ironic-python-agent.initramfs | zcat | cpio -ivd
 # NOTE(elfosardo) we could inject a list of packages that we want to add, based

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -18,6 +18,14 @@ cd $TMPDIR_RAMDISK
 rpm2cpio /tmp/packages/openstack-ironic-python-agent*.rpm | cpio -ivdum
 rpm2cpio /tmp/packages/python3-ironic-python-agent*.rpm | cpio -ivdum
 rpm2cpio /tmp/packages/python3-ironic-lib*.rpm | cpio -ivdum
+
+# Update netconfig to use MAC for DUID/IAID combo (same as RHCOS)
+# FIXME: we need an alternative of this packaged
+mkdir -p etc/NetworkManager/conf.d etc/NetworkManager/dispatcher.d
+echo -e '[main]\ndhcp=dhclient\n[connection]\nipv6.dhcp-duid=ll' > etc/NetworkManager/conf.d/clientid.conf
+echo -e '[[ "$DHCP6_FQDN_FQDN" =~ - ]] && hostname $DHCP6_FQDN_FQDN' > etc/NetworkManager/dispatcher.d/01-hostname
+chmod +x etc/NetworkManager/dispatcher.d/01-hostname
+
 find . 2>/dev/null | cpio -c -o | gzip -8  > /var/tmp/ironic-python-agent.initramfs
 cp $TMPDIR/ironic-python-agent.kernel /var/tmp/
 cd /var/tmp

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+TMPDIR=$(mktemp -d -p /var/tmp)
+TMPDIR_RAMDISK=$(mktemp -d -p /var/tmp)
+IPA_RAMDISK_VERSION=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}" rhosp-director-images-ipa-x86_64)
+
+chmod 755 $TMPDIR $TMPDIR_RAMDISK
+cd $TMPDIR
+tar -xf /usr/share/rhosp-director-images/ironic-python-agent-${IPA_RAMDISK_VERSION}.$(uname -m).tar
+cd $TMPDIR_RAMDISK
+/usr/lib/dracut/skipcpio $TMPDIR/ironic-python-agent.initramfs | zcat | cpio -ivd
+# NOTE(elfosardo) we could inject a list of packages that we want to add, based
+# on what we download in the main image and call this part only if we actually
+# have packages in the list.
+# Also version tagging is something we should consider.
+# And cookies.
+rpm2cpio /tmp/packages/openstack-ironic-python-agent*.rpm | cpio -ivdum
+rpm2cpio /tmp/packages/python3-ironic-python-agent*.rpm | cpio -ivdum
+rpm2cpio /tmp/packages/python3-ironic-lib*.rpm | cpio -ivdum
+find . 2>/dev/null | cpio -c -o | gzip -8  > /var/tmp/ironic-python-agent.initramfs
+cp $TMPDIR/ironic-python-agent.kernel /var/tmp/
+cd /var/tmp
+ls -la
+rm -fr $TMPDIR $TMPDIR_RAMDISK

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -11,21 +11,13 @@ FFILENAME=$FILENAME$FILENAME_EXT
 mkdir -p /shared/html/images /shared/tmp
 cd /shared/html/images
 
-TMPDIR=$(mktemp -d -p /shared/tmp)
-
 # Is this a RHEL based image? If so the IPA image is already here, so
 # we don't need to download it
-if [ -e /usr/share/rhosp-director-images/ironic-python-agent-latest.tar ] ; then
-    VERSION=$(cat /usr/share/rhosp-director-images/version-latest.txt)
-    if [ ! -e $FILENAME-$VERSION ] ; then
-        cd $TMPDIR
-        tar -xf /usr/share/rhosp-director-images/ironic-python-agent-latest.tar
-        chmod 755 $TMPDIR
-        cd -
-        mv $TMPDIR $FILENAME-$VERSION
-    fi
-    ln -sf $FILENAME-$VERSION/$FILENAME.initramfs $FILENAME.initramfs
-    ln -sf $FILENAME-$VERSION/$FILENAME.kernel $FILENAME.kernel
+if [[ -e /var/tmp/$FILENAME.initramfs && \
+      -e /var/tmp/$FILENAME.kernel ]] ; then
+    mv /var/tmp/$FILENAME.initramfs $FILENAME.initramfs
+    mv /var/tmp/$FILENAME.kernel $FILENAME.kernel
+    mv /var/tmp/ipa-ramdisk-pkgs.info ipa-ramdisk-pkgs.info
     exit 0
 fi
 


### PR DESCRIPTION
Backport the Change to set hostnames and make DHCPv6 IDs predictable

This patch also depends on 
 - Add a way to build/modify ipa image
and its fix
 - Ramdisk arch should not be hardcoded

Finally the 4 commit is backported to simplify conflicts
- Use dnf to download the only package we need