### PR TITLE
Delegate builder for ipa-ramdisk operations

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM ubi8
+FROM ironic-builder AS builder
 
 # We don't need the deps that rhosp-director-images-ipa pulls in
 # use rpm to install without them to keep the image size down as
@@ -19,5 +19,11 @@ RUN dnf update -y && \
     dnf remove -y rhosp-director-images-ipa-$(uname -m) && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
+
+FROM ubi8
+
+COPY --from=builder /var/tmp/ipa-ramdisk-pkgs.info /var/tmp/
+COPY --from=builder /var/tmp/ironic-python-agent.initramfs /var/tmp/
+COPY --from=builder /var/tmp/ironic-python-agent.kernel /var/tmp/
 
 COPY ./get-resource.sh /usr/local/bin/get-resource.sh


### PR DESCRIPTION
With this patch we move all the moving parts of the ipa-ramdisk
creation to a builder and just take what we need from it into the
final image.

This depends on openshift/release#7119
Then we need openshift/ocp-build-data#319 and openshift/ocp-build-data#320

Then we can merge this one.
