### PR TITLE
Bug 1841355: Force rebuild of ironic-ipa-downloader image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # ironic-ipa-downloader
+
 Download the IPA ramdisk images to a shared volume


### PR DESCRIPTION
OpenShift CI does not periodically rebuild images automatically when new
packages are available. This change is being used to force CI to build
us a new image that has efibootmgr installed.