### PR TITLE
Use chroot to modify the ipa-ramdisk

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -6,11 +6,18 @@ FROM ironic-builder AS builder
 
 COPY ./build-ipa.sh /usr/local/bin/build-ipa.sh
 
-RUN dnf update -y && \
-    dnf install -y cpio dracut && \
+RUN dnf upgrade -y && \
+    dnf install -y \
+      cpio \
+      dracut \
+      && \
     dnf download --destdir /tmp/packages \
-      rhosp-director-images-ipa-$(uname -m) python3-ironic-lib \
-      python3-ironic-python-agent openstack-ironic-python-agent && \
+      openstack-ironic-python-agent \
+      python3-bcrypt \
+      python3-ironic-lib \
+      python3-ironic-python-agent \
+      rhosp-director-images-ipa-$(uname -m) \
+      && \
     rpm -i --nodeps /tmp/packages/rhosp-director-images-ipa-*.rpm && \
     chmod +x /usr/local/bin/build-ipa.sh && \
     /usr/local/bin/build-ipa.sh && \

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -16,16 +16,29 @@ cd $TMPDIR_RAMDISK
 # have packages in the list.
 # Also version tagging is something we should consider.
 # And cookies.
-rpm2cpio /tmp/packages/openstack-ironic-python-agent*.rpm | cpio -ivdum
-rpm2cpio /tmp/packages/python3-ironic-python-agent*.rpm | cpio -ivdum
-rpm2cpio /tmp/packages/python3-ironic-lib*.rpm | cpio -ivdum
+mv /tmp/packages/*.rpm .
+
+# NOTE(elfosardo) to prevent the ``BDB0091 DB_VERSION_MISMATCH: Database
+# environment version mismatch`` error, we need to remove the rpm lock.
+rm var/lib/rpm/.rpm.lock
+
+chroot . /bin/bash -x <<'EOF'
+rpm -Uvh \
+openstack-ironic-python-agent*.rpm \
+python3-bcrypt*.rpm \
+python3-ironic-python-agent*.rpm \
+python3-ironic-lib*.rpm || { exit 1; }
+
+rm -f *.rpm
 
 # Update netconfig to use MAC for DUID/IAID combo (same as RHCOS)
 # FIXME: we need an alternative of this packaged
-mkdir -p etc/NetworkManager/conf.d etc/NetworkManager/dispatcher.d
-echo -e '[main]\ndhcp=dhclient\n[connection]\nipv6.dhcp-duid=ll' > etc/NetworkManager/conf.d/clientid.conf
-echo -e '[[ "$DHCP6_FQDN_FQDN" =~ - ]] && hostname $DHCP6_FQDN_FQDN' > etc/NetworkManager/dispatcher.d/01-hostname
-chmod +x etc/NetworkManager/dispatcher.d/01-hostname
+mkdir -p /etc/NetworkManager/conf.d /etc/NetworkManager/dispatcher.d
+echo -e '[main]\ndhcp=dhclient\n[connection]\nipv6.dhcp-duid=ll' > /etc/NetworkManager/conf.d/clientid.conf
+echo -e '[[ "$DHCP6_FQDN_FQDN" =~ - ]] && hostname $DHCP6_FQDN_FQDN' > /etc/NetworkManager/dispatcher.d/01-hostname
+chmod +x /etc/NetworkManager/dispatcher.d/01-hostname
+
+EOF
 
 find . 2>/dev/null | cpio -c -o | gzip -8  > /var/tmp/ironic-python-agent.initramfs
 cp $TMPDIR/ironic-python-agent.kernel /var/tmp/


### PR DESCRIPTION
So far we've used a very unreliable hack to modify the ipa-ramdisk
and, for example, install new updated content.
We switch to a different more reliable hack using chroot, which
allows us to trigger native mechanisms (like dependency check)
when installing the updated packages.

To be able to run the installation we need to remove the rpm lock
to prevent the ``BDB0091 DB_VERSION_MISMATCH: Database environment
version mismatch``.
In a normal system, we could this in a different way, for example
running ``dnf clean dbcache``, but doing that in a chroot
environment inside a container will simply raise more problems
related to dnf.