### PR TITLE
Bug 1863390: Use dnf to install packages in the ipa ramdisk

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -5,23 +5,15 @@ FROM ironic-builder AS builder
 # much as possible
 
 COPY ./build-ipa.sh /usr/local/bin/build-ipa.sh
+COPY ./chrooted.sh /usr/local/bin/chrooted.sh
 
 RUN dnf upgrade -y && \
-    dnf install -y \
-      cpio \
-      dracut \
-      && \
-    dnf download --destdir /tmp/packages \
-      openstack-ironic-python-agent \
-      python3-bcrypt.$(uname -m) \
-      python3-ironic-lib \
-      python3-ironic-python-agent \
-      rhosp-director-images-ipa-$(uname -m) \
-      && \
+    dnf install -y cpio dracut && \
+    dnf download --destdir /tmp/packages rhosp-director-images-ipa-$(uname -m) && \
     rpm -i --nodeps /tmp/packages/rhosp-director-images-ipa-*.rpm && \
     chmod +x /usr/local/bin/build-ipa.sh && \
     /usr/local/bin/build-ipa.sh && \
-    rpm -q --queryformat "%{NAME} %{VERSION} %{RELEASE} %{ARCH}\n" /tmp/packages/*.rpm > /var/tmp/ipa-ramdisk-pkgs.info && \
+    rpm -q --queryformat "%{NAME} %{VERSION} %{RELEASE} %{ARCH}\n" /tmp/packages/rhosp-director-images-ipa-*.rpm > /var/tmp/ipa-ramdisk-image.info && \
     rm -rf /tmp/packages && \
     dnf remove -y rhosp-director-images-ipa-$(uname -m) && \
     dnf clean all && \
@@ -29,7 +21,8 @@ RUN dnf upgrade -y && \
 
 FROM ubi8
 
-COPY --from=builder /var/tmp/ipa-ramdisk-pkgs.info /var/tmp/
+COPY --from=builder /var/tmp/ipa-ramdisk-image.info /var/tmp/
+COPY --from=builder /var/tmp/ipa-ramdisk-pkgs-list.txt /var/tmp/
 COPY --from=builder /var/tmp/ironic-python-agent.initramfs /var/tmp/
 COPY --from=builder /var/tmp/ironic-python-agent.kernel /var/tmp/
 

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -10,38 +10,33 @@ chmod 755 $TMPDIR $TMPDIR_RAMDISK
 cd $TMPDIR
 tar -xf /usr/share/rhosp-director-images/ironic-python-agent-${IPA_RAMDISK_VERSION}.${IPA_RAMDISK_ARCH}.tar
 cd $TMPDIR_RAMDISK
+
+# Extract the ipa-ramdisk filesystem
 /usr/lib/dracut/skipcpio $TMPDIR/ironic-python-agent.initramfs | zcat | cpio -ivd
-# NOTE(elfosardo) we could inject a list of packages that we want to add, based
-# on what we download in the main image and call this part only if we actually
-# have packages in the list.
-# Also version tagging is something we should consider.
-# And cookies.
-mv /tmp/packages/*.rpm .
 
 # NOTE(elfosardo) to prevent the ``BDB0091 DB_VERSION_MISMATCH: Database
 # environment version mismatch`` error, we need to remove the rpm lock.
 rm var/lib/rpm/.rpm.lock
 
-chroot . /bin/bash -x <<'EOF'
-rpm -Uvh \
-openstack-ironic-python-agent*.rpm \
-python3-bcrypt*.rpm \
-python3-ironic-python-agent*.rpm \
-python3-ironic-lib*.rpm || { exit 1; }
+# Prepare the chroot environment
+cp /etc/resolv.conf etc/resolv.conf
+mv etc/yum.repos.d/* .
+cp /etc/yum.repos.d/* etc/yum.repos.d/
+cp /usr/local/bin/chrooted.sh .
 
-rm -f *.rpm
+# Modify the ipa-ramdisk in chroot
+chroot . ./chrooted.sh
 
-# Update netconfig to use MAC for DUID/IAID combo (same as RHCOS)
-# FIXME: we need an alternative of this packaged
-mkdir -p /etc/NetworkManager/conf.d /etc/NetworkManager/dispatcher.d
-echo -e '[main]\ndhcp=dhclient\n[connection]\nipv6.dhcp-duid=ll' > /etc/NetworkManager/conf.d/clientid.conf
-echo -e '[[ "$DHCP6_FQDN_FQDN" =~ - ]] && hostname $DHCP6_FQDN_FQDN' > /etc/NetworkManager/dispatcher.d/01-hostname
-chmod +x /etc/NetworkManager/dispatcher.d/01-hostname
+# Provide list of packages installed in the ipa-ramdisk
+cp ipa-ramdisk-pkgs-list.txt /var/tmp/
 
-EOF
-
+# Compress the ipa-ramdisk and copy it in the right place
 find . 2>/dev/null | cpio -c -o | gzip -8  > /var/tmp/ironic-python-agent.initramfs
 cp $TMPDIR/ironic-python-agent.kernel /var/tmp/
+
+# Clean temp directories
+rm -fr $TMPDIR $TMPDIR_RAMDISK
+
+# Debug Steps
 cd /var/tmp
 ls -la
-rm -fr $TMPDIR $TMPDIR_RAMDISK

--- a/chrooted.sh
+++ b/chrooted.sh
@@ -1,0 +1,24 @@
+set -ex
+
+# Install the packages we need in the ipa-ramdisk
+dnf --best install -y \
+    openstack-ironic-python-agent \
+    python3-ironic-python-agent \
+    python3-ironic-lib
+
+# Update netconfig to use MAC for DUID/IAID combo (same as RHCOS)
+# FIXME: we need an alternative of this packaged
+mkdir -p /etc/NetworkManager/conf.d /etc/NetworkManager/dispatcher.d
+echo -e '[main]\ndhcp=dhclient\n[connection]\nipv6.dhcp-duid=ll' > /etc/NetworkManager/conf.d/clientid.conf
+echo -e '[[ "$DHCP6_FQDN_FQDN" =~ - ]] && hostname $DHCP6_FQDN_FQDN' > /etc/NetworkManager/dispatcher.d/01-hostname
+chmod +x /etc/NetworkManager/dispatcher.d/01-hostname
+
+# Provide a list of packages installed in the ipa-ramdisk
+rpm -qa | sort > ipa-ramdisk-pkgs-list.txt
+
+# Cleaning steps
+dnf clean all
+rm -rf /var/cache/{yum,dnf}/*
+rm -f /etc/resolv.conf
+rm -f /etc/yum.repos.d/*
+mv /*.repo /etc/yum.repos.d/

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -21,7 +21,8 @@ if [[ -e /var/tmp/$FILENAME.initramfs && \
       -e /var/tmp/$FILENAME.kernel ]] ; then
     mv /var/tmp/$FILENAME.initramfs $FILENAME.initramfs
     mv /var/tmp/$FILENAME.kernel $FILENAME.kernel
-    mv /var/tmp/ipa-ramdisk-pkgs.info ipa-ramdisk-pkgs.info
+    mv /var/tmp/ipa-ramdisk-image.info ipa-ramdisk-image.info
+    mv /var/tmp/ipa-ramdisk-pkgs-list.txt ipa-ramdisk-pkgs-list.txt
     exit 0
 fi
 


### PR DESCRIPTION
Move the logic to modify the ipa-ramdisk to the chrooted.sh script
that is executed in a chroot environment.
This allows us to use native commands directly in the ipa-ramdisk
image, like dnf, and exit correctly in case of failures.
Also provide a list of packages installed in the ipa-ramdisk.