### PR TITLE
Bug 1873976: Install packages from file content

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -6,6 +6,7 @@ FROM ironic-builder AS builder
 
 COPY ./build-ipa.sh /usr/local/bin/build-ipa.sh
 COPY ./chrooted.sh /usr/local/bin/chrooted.sh
+COPY ./ipa-ramdisk-packages-list.txt /tmp/ipa-ramdisk-packages-list.txt
 
 RUN dnf upgrade -y && \
     dnf install -y cpio dracut && \

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -23,6 +23,7 @@ cp /etc/resolv.conf etc/resolv.conf
 mv etc/yum.repos.d/* .
 cp /etc/yum.repos.d/* etc/yum.repos.d/
 cp /usr/local/bin/chrooted.sh .
+cp /tmp/ipa-ramdisk-packages-list.txt tmp/
 
 # Modify the ipa-ramdisk in chroot
 chroot . ./chrooted.sh

--- a/chrooted.sh
+++ b/chrooted.sh
@@ -1,10 +1,7 @@
 set -ex
 
 # Install the packages we need in the ipa-ramdisk
-dnf --best install -y \
-    openstack-ironic-python-agent \
-    python3-ironic-python-agent \
-    python3-ironic-lib
+dnf --best install -y $(cat /tmp/ipa-ramdisk-packages-list.txt)
 
 # Update netconfig to use MAC for DUID/IAID combo (same as RHCOS)
 # FIXME: we need an alternative of this packaged
@@ -22,3 +19,4 @@ rm -rf /var/cache/{yum,dnf}/*
 rm -f /etc/resolv.conf
 rm -f /etc/yum.repos.d/*
 mv /*.repo /etc/yum.repos.d/
+rm -f /tmp/ipa-ramdisk-packages-list.txt

--- a/ipa-ramdisk-packages-list.txt
+++ b/ipa-ramdisk-packages-list.txt
@@ -1,0 +1,4 @@
+openstack-ironic-python-agent
+python3-ironic-python-agent
+python3-ironic-lib
+


### PR DESCRIPTION
An improvement for testing and customization, moving all the
files we need to install in the ipa-ramdisk to a file and having
dnf read its content.
This allows exotic compositions of sources, like urls and local dirs,
without having to touch the Dockerfile.