### PR TITLE
Updating ironic-ipa-downloader builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift AS builder
 
 # We don't need the deps that rhosp-director-images-ipa pulls in
 # use rpm to install without them to keep the image size down as
@@ -23,7 +23,7 @@ RUN dnf upgrade -y && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
 COPY --from=builder /var/tmp/ipa-ramdisk-image.info /var/tmp/
 COPY --from=builder /var/tmp/ipa-ramdisk-pkgs-list.txt /var/tmp/


### PR DESCRIPTION
Updating ironic-ipa-downloader builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ironic-ipa-downloader.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
