### PR TITLE
Add tenacity lib to installed packages

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,4 +1,4 @@
 openstack-ironic-python-agent
 python3-ironic-python-agent
 python3-ironic-lib
-
+python3-tenacity


### PR DESCRIPTION
This is to prevent ironic-python-agent failure as the package is
currently missing from the specs.