### PR TITLE
Bug 1899190: Apply hack to eventlet

### DIFF
--- a/chrooted.sh
+++ b/chrooted.sh
@@ -13,6 +13,9 @@ chmod +x /etc/NetworkManager/dispatcher.d/01-hostname
 # Provide a list of packages installed in the ipa-ramdisk
 rpm -qa | sort > ipa-ramdisk-pkgs-list.txt
 
+#HACK: Apply https://github.com/eventlet/eventlet/commit/45019326b68d6a151745056bdc418b8062399606
+sed -ie '/set_nonblocking(newsock)/d' /usr/lib/python3.6/site-packages/eventlet/green/ssl.py
+
 # Cleaning steps
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
This hack has been applied to OCP 4.7 and it's backported to 4.6 as we're seeing the same issue with SSL failing with ssl.SSLWantReadError
For more info please check https://github.com/eventlet/eventlet/issues/308

(cherry picked from commit f2bde9449e9981abf89d736b32338c1b58e70098)