### PR TITLE
Bug 1995531: Add Support for OKD

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,0 +1,16 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift AS builder
+
+COPY ./get-resource.sh /usr/local/bin/get-resource.sh
+
+RUN /usr/local/bin/get-resource.sh
+
+RUN IPA_DIR=$(dirname "$(readlink -e /shared/html/images/ironic-python-agent.initramfs)") && \
+    mv $IPA_DIR/ironic-python-agent.initramfs /var/tmp/ && \
+    mv $IPA_DIR/ironic-python-agent.kernel /var/tmp/
+
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
+
+COPY --from=builder /var/tmp/ironic-python-agent.initramfs /var/tmp/
+COPY --from=builder /var/tmp/ironic-python-agent.kernel /var/tmp/
+
+COPY ./get-resource.sh /usr/local/bin/get-resource.sh


### PR DESCRIPTION
Adds an OKD-specific Dockerfile.
Adapts get-resource.sh to work with pre-provided IPA image from RDO,
which comes without a manifest.
Pulls im some formatting and curl flag changes into get-resource.sh from
upstream.
Restores the TMPDIR initialization missing here in downstream
get-resource.sh.