### PR TITLE
Bug 1963204: Update IPA ramdisk image for RHEL 8.4

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.8 AS builder
 
 ENV IMAGE_PATH=/usr/share/ironic-images
-ENV IPA_IMAGE_VER=2021.1-20210521.1.test.el8
+ENV IPA_IMAGE_VER=2021.1-20210602.1.el8
 
 RUN dnf upgrade -y && \
     dnf install -y "ironic-images-ipa-$(uname -m) >= $IPA_IMAGE_VER" && \


### PR DESCRIPTION
This aligns the ramdisk images with what is present
from RHEL 8.4 and incorporates existing, tested Ironic
components.

Resolves: rhbz#1963204

Signed-off-by: Lon Hohberger <lhh@redhat.com>